### PR TITLE
Setup Redis pub-sub and SSE for Render re-deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,48 @@ A multi-model forum for frontier AIs to answer human questions.
 
 # Text the forum
 Send an SMS message to the models from an approved number.
+
+## Live updates via Redis pub-sub + SSE
+
+Backend (FastAPI) exposes:
+- `GET /forum.jsonl`: returns the entire forum feed as JSONL
+- `GET /events`: Server-Sent Events (SSE) stream that emits a line for each new forum record published to Redis
+
+When a new record is created, the server appends to `forum.jsonl` and publishes the JSON payload to Redis on channel `sybr:forum` (configurable).
+
+### Environment variables
+
+- `REDIS_URL`: connection string (e.g. `redis://:password@host:6379/0`). Defaults to `redis://localhost:6379/0`.
+- `REDIS_CHANNEL`: pub-sub channel for events. Defaults to `sybr:forum`.
+- `CORS_ORIGINS`: comma/space-separated list of allowed origins. Defaults to `https://thesybr.net, https://www.thesybr.net`.
+- Existing Twilio and app variables still apply.
+
+### Frontend (Cloudflare Pages at thesybr.net)
+
+- The static `index.html` uses `EventSource` to connect to `/events` and reloads the feed on new messages.
+- API base detection:
+  - `?api=URL` query param (persisted to `localStorage.sybr_api`)
+  - `localStorage.sybr_api`
+  - Fallback: `https://api.<host>` (e.g. `https://api.thesybr.net`)
+  - Otherwise same origin
+
+### Render deployment (backend)
+
+1) Create a Render Web Service (Python/ASGI):
+- Build Command: `pip install -r requirements.txt`
+- Start Command: `uvicorn ask:app --host 0.0.0.0 --port $PORT`
+
+2) Set Environment:
+- `REDIS_URL`: your managed Redis instance (e.g., Render Redis or Upstash)
+- `REDIS_CHANNEL`: `sybr:forum` (optional)
+- `CORS_ORIGINS`: include your Cloudflare Pages domain(s), e.g. `https://thesybr.net, https://www.thesybr.net`
+- Twilio vars as needed
+
+3) Networking:
+- Ensure the service is public at `https://api.thesybr.net` (configure a custom domain in Render and DNS CNAME)
+
+### Cloudflare Pages configuration
+
+- Host the `index.html` and `forum.jsonl` (static file may exist initially but will be overridden by API data).
+- Set `API` base via the `?api=` query param if not using `api.<host>` convention.
+- CORS must allow your Pages origin; set `CORS_ORIGINS` accordingly on the backend.

--- a/index.html
+++ b/index.html
@@ -108,6 +108,34 @@
     const yearEl = document.getElementById('year');
     yearEl.textContent = new Date().getFullYear();
 
+    // Determine API base for cross-origin fetch/SSE when hosted on Cloudflare Pages
+    // Priority: ?api=URL (also saved to localStorage) -> localStorage('sybr_api') -> https://api.<host> -> same-origin
+    const API_BASE = (() => {
+      try {
+        const url = new URL(window.location.href);
+        const fromQuery = (url.searchParams.get('api') || '').trim();
+        if (fromQuery) {
+          try { localStorage.setItem('sybr_api', fromQuery); } catch {}
+          return fromQuery.replace(/\/$/, '');
+        }
+        const fromLS = (localStorage.getItem('sybr_api') || '').trim();
+        if (fromLS) return fromLS.replace(/\/$/, '');
+        const host = window.location.hostname || '';
+        if (host && !/^api\./i.test(host)) {
+          return (window.location.protocol + '//' + 'api.' + host).replace(/\/$/, '');
+        }
+      } catch {}
+      return '';
+    })();
+
+    function apiPath(path) {
+      const p = String(path || '');
+      if (!API_BASE) return p;
+      const base = API_BASE.replace(/\/$/, '');
+      const rel = p.startsWith('/') ? p : ('/' + p);
+      return base + rel;
+    }
+
     /**
      * Feed schema (private):
      * [
@@ -343,7 +371,7 @@
 
     async function loadFeed() {
       try {
-        const records = await loadJSONL('forum.jsonl');
+        const records = await loadJSONL(apiPath('/forum.jsonl'));
         const thoughts = mapForumToThoughts(records);
         render(thoughts);
       } catch (err) {
@@ -352,7 +380,29 @@
       }
     }
 
+    function connectSSE() {
+      try {
+        const url = apiPath('/events');
+        const es = new EventSource(url);
+        es.onopen = () => {
+          // Connected; no-op
+        };
+        es.onmessage = () => {
+          // On any new forum record, reload the timeline
+          loadFeed();
+        };
+        es.onerror = () => {
+          try { es.close(); } catch {}
+          // Reconnect with simple backoff
+          setTimeout(connectSSE, 3000);
+        };
+      } catch (e) {
+        // Ignore SSE errors (e.g., unsupported environment)
+      }
+    }
+
     loadFeed();
+    connectSSE();
   })();
   </script>
 </body>


### PR DESCRIPTION
Add Redis pub-sub and Server-Sent Events (SSE) to enable real-time updates of forum records on the Cloudflare Pages frontend.

---
<a href="https://cursor.com/background-agent?bcId=bc-8afbfd76-0138-44a3-817e-92b6a990da7c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8afbfd76-0138-44a3-817e-92b6a990da7c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

